### PR TITLE
Configure intro to show weekdays

### DIFF
--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -3,8 +3,8 @@
     "specificDate": "Scegli un giorno specifico: ",
     "previousDay": "Vai al giorno precedente",
     "nextDay": "Vai al giorno successivo",
-    "futureQuestion": "Impaziente? Stai sbirciando la domanda del {date}:",
-    "pastQuestion": "La domanda del {date} era:",
+    "futureQuestion": "Impaziente? Stai sbirciando la domanda di {date}:",
+    "pastQuestion": "La domanda di {date} era:",
     "todayQuestion": "Preparati a rispondere! La domanda di oggi è:",
     "language": "Lingua",
     "questions": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,12 +21,12 @@ const i18n = createI18n({
   datetimeFormats: {
     en: {
       long: {
-        month: 'long', day: 'numeric'
+        month: 'long', day: 'numeric', weekday: 'long'
       }
     },
     it: {
       long: {
-        month: 'long', day: 'numeric'
+        month: 'long', day: 'numeric', weekday: 'long'
       }
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Refined Italian translations for date-related interface text.

* **Improvements**
  * Extended date format now displays the full weekday name (e.g., Monday, Tuesday) alongside the date for better clarity across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->